### PR TITLE
fix: disable precompressed jetty init-param (production)

### DIFF
--- a/conf/jetty/webdefault.xml.production
+++ b/conf/jetty/webdefault.xml.production
@@ -177,7 +177,7 @@
     </init-param>
     <init-param>
       <param-name>precompressed</param-name>
-      <param-value>true</param-value>
+      <param-value>false</param-value>
     </init-param>
     <init-param>
       <param-name>useFileMappedBuffer</param-name>


### PR DESCRIPTION
Disables precompressed init-param for jetty for production (temporary fox for web)