### PR TITLE
fix: [CO-642] Fix broken config of jetty default configuration file

### DIFF
--- a/conf/jetty/jetty.xml.production
+++ b/conf/jetty/jetty.xml.production
@@ -940,7 +940,6 @@
           </Array>
         </Set>
 
-        <!-- Modern UI uses build time compression -->
         <Set name="excludedPaths">
           <Array type="String">
             <Item>/modern/*</Item>


### PR DESCRIPTION
**What has changed:**

- remove the comment cuasing the broken xml syntax when HttpCompressionEnabled attribute is set to false
