### PR TITLE
fix: npn directory

### DIFF
--- a/appserver/PKGBUILD
+++ b/appserver/PKGBUILD
@@ -85,7 +85,7 @@ package() {
   install -D conf/jetty/modules/mail.mod \
     "${pkgdir}/opt/zextras/jetty_base/modules/mail.mod"
 
-  install -D conf/jetty/modules/npn \
+  install -D conf/jetty/modules/npn/npn-1.7.0_51.mod \
     "${pkgdir}/opt/zextras/jetty_base/modules/npn"
 
   install -D conf/jetty/modules/rewrite.mod \


### PR DESCRIPTION
- put back original instructions but using local repo sources
- bump 4.1.1

Original PKGBUILD in 24.1.0 was appserver PKGBUILD: https://github.com/zextras/carbonio-core/pull/46/files#diff-3dabacea4af330e310d07293bb5a11f33b4d817f7a3a54cb5cfe4e34e6302ed8