### PR TITLE
chore(ci): move properties(defaultPipelineProperties()) to top-level scope

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,8 @@ library(
     ])
 )
 
+properties(defaultPipelineProperties())
+
 pipeline {
     agent {
         node {
@@ -33,7 +35,6 @@ pipeline {
                 checkout scm
                 script {
                     gitMetadata()
-                    properties(defaultPipelineProperties())
                 }
             }
         }


### PR DESCRIPTION
Applies Jenkins library improvements from spec files:

## Changes
- **default-pipeline-properties**: Moved `properties(defaultPipelineProperties())` from inside the Setup stage to top-level scope after library imports

This change ensures Jenkins pipeline properties are configured at the correct execution point in the pipeline lifecycle.

Refs: [IN-982](https://zextras.atlassian.net/browse/IN-982)

[IN-982]: https://zextras.atlassian.net/browse/IN-982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ