### PR TITLE
chore: add carbonio-appserver.slice

### DIFF
--- a/appserver/PKGBUILD
+++ b/appserver/PKGBUILD
@@ -25,11 +25,13 @@ depends=(
 )
 
 source=(
+  "${pkgname}.slice"
   "${pkgname}.target"
   "systemd-tmpfile.conf"
 )
 
 sha256sums=(
+  'ad105fda6d4b4c34ec227d329a508111b2739fcb1bd9cabca409d402d1be763b'
   'efd70576906f667cab1f2d21a31ddcd4250244be5f63b6465e22678aafc12413'
   '51565ef1d7f2483138b9eecee084df5eebdc86262649a4be7652411c62ea36ee'
 )
@@ -65,7 +67,9 @@ package() {
   # systemd units and target
   mkdir -p "${pkgdir}/usr/lib/systemd/system/carbonio.target.wants"
   mkdir -p "${pkgdir}/usr/lib/systemd/system/${pkgname}.target.wants"
-  install -Dm 644 "${srcdir}/${pkgname}.target" \
+  install -Dm644 "${srcdir}/${pkgname}.slice" \
+    "${pkgdir}/usr/lib/systemd/system/${pkgname}.slice"
+  install -Dm644 "${srcdir}/${pkgname}.target" \
     "${pkgdir}/usr/lib/systemd/system/${pkgname}.target"
   ln -sf "/usr/lib/systemd/system/${pkgname}.target" \
     "${pkgdir}/usr/lib/systemd/system/carbonio.target.wants/${pkgname}.target"

--- a/appserver/carbonio-appserver.slice
+++ b/appserver/carbonio-appserver.slice
@@ -1,0 +1,31 @@
+[Unit]
+Description=Carbonio Appserver Slice
+Documentation=man:systemd.slice(5)
+Before=slices.target
+PartOf=carbonio-appserver.target
+StopWhenUnneeded=yes
+
+[Slice]
+# Application tier: appserver (Java/Jetty), appserver-db (MariaDB)
+# These are the heaviest resource consumers
+#
+# Scaling guide:
+#   Small  (8GB RAM):   ~4GB effective (50% of 8GB)
+#   Medium (32GB RAM):  ~16GB effective (50% of 32GB)
+#   Large  (64GB RAM):  ~32GB effective (50% of 64GB)
+
+# Memory controls - percentage-based for automatic scaling
+# MemoryHigh: soft limit, triggers reclaim when exceeded
+# MemoryMax: hard limit, OOM killer if exceeded
+MemoryMax=50%
+MemoryHigh=45%
+
+# CPU weight: highest priority (mailbox is user-facing)
+CPUWeight=100
+
+# I/O weight: highest priority (database operations)
+IOWeight=100
+
+# Process/thread limit (Java + MariaDB need many threads)
+# Scale: ~100 threads per 1000 concurrent users
+TasksMax=4096


### PR DESCRIPTION
Add the slice file alongside the target where it logically belongs. Updated PKGBUILD to include slice in source array and install it.

Refs: CO-2513