### PR TITLE
chore(deps): update dependency zextras/jenkins-lib-common to v4.1.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@v2.8.7',
+    identifier: 'jenkins-lib-common@v4.1.4',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',


### PR DESCRIPTION
Pin-only bump to `jenkins-lib-common@v4.1.4`. Repo is already past v2.0.0 (trunk-based branch-guard change), so that break does not apply. No `gitleaksStage()` call and no `uploadStage(packages:)` argument present, so the removed-`packages`/gitleaks-pod breaks do not apply either. Verified against the Nexus mirror of jenkins-lib-common.

Ref: https://zextras.atlassian.net/browse/IN-1168